### PR TITLE
Add simple password login with cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ This is a simple LAMP-based website for storing and sharing travel information a
    ```bash
    chmod 777 uploads
    ```
-4. Access `index.php` to view the site and `admin.php` to manage content.
+4. Edit `config.php` and set the `$site_password` variable to the password you
+   want to use for accessing the site.
+5. Open `login.php` in your browser and enter the password. A cookie will be
+   stored so you do not need to log in on every visit.
+6. Once logged in you can access `index.php` and `admin.php` normally.
 
 ## Security Note
-This example omits authentication and advanced security for brevity. In production you should secure the administration interface and sanitize inputs further.
+This project now includes a very basic password protection mechanism. All pages require the password specified in `config.php` and set a cookie once authenticated. For production use you should implement a more robust authentication system and sanitize inputs further.

--- a/admin.php
+++ b/admin.php
@@ -1,5 +1,6 @@
 <?php
 require 'config.php';
+require 'auth.php';
 
 // Handle document upload
 if (isset($_POST['upload']) && !empty($_FILES['document']['name'])) {
@@ -71,9 +72,8 @@ $events    = $pdo->query('SELECT * FROM events ORDER BY event_date ASC')->fetchA
 </head>
 <body>
     <h1>Administration</h1>
-    <p><a href="index.php">Back to main page</a></p>
-
-    <section>
+    <p><a href="index.php">Back to main page</a> | <a href='logout.php'>Logout</a></p>
+<section>
         <h2>Documents</h2>
         <form method="post" enctype="multipart/form-data">
             <input type="file" name="document" required>

--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,8 @@
+<?php
+require_once 'config.php';
+$expected = hash('sha256', $site_password);
+if (!isset($_COOKIE['travel_auth']) || !hash_equals($expected, $_COOKIE['travel_auth'])) {
+    header('Location: login.php');
+    exit;
+}
+?>

--- a/config.php
+++ b/config.php
@@ -1,6 +1,8 @@
 <?php
 // Database connection settings
 $host = 'localhost';
+// Password required to access the site
+$site_password = 'changeme';
 $db   = 'travel_db';
 $user = 'travel_user';
 $pass = 'travel_pass';

--- a/index.php
+++ b/index.php
@@ -1,5 +1,6 @@
 <?php
 require 'config.php';
+require "auth.php";
 //$documents
 $stmt = $pdo->query('SELECT * FROM documents ORDER BY uploaded_at DESC');
 $documents = $stmt->fetchAll();
@@ -25,7 +26,7 @@ $events = $stmt->fetchAll();
 </head>
 <body>
     <h1>Travel Information Portal</h1>
-    <p><a href="admin.php">Administration</a></p>
+    <p><a href="admin.php">Administration</a> | <a href="logout.php">Logout</a></p>
 
     <section>
         <h2>Uploaded Documents</h2>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,40 @@
+<?php
+require 'config.php';
+$hash = hash('sha256', $site_password);
+if (isset($_COOKIE['travel_auth']) && hash_equals($hash, $_COOKIE['travel_auth'])) {
+    header('Location: index.php');
+    exit;
+}
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $password = $_POST['password'] ?? '';
+    if (hash_equals($site_password, $password)) {
+        setcookie('travel_auth', $hash, time() + 30*24*60*60, '/');
+        header('Location: index.php');
+        exit;
+    } else {
+        $error = 'Invalid password';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .error { color: red; }
+    </style>
+</head>
+<body>
+    <h1>Login</h1>
+    <?php if ($error): ?>
+        <p class="error"><?php echo htmlspecialchars($error); ?></p>
+    <?php endif; ?>
+    <form method="post">
+        Password: <input type="password" name="password" required>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,5 @@
+<?php
+setcookie('travel_auth', '', time() - 3600, '/');
+header('Location: login.php');
+exit;
+?>


### PR DESCRIPTION
## Summary
- protect site with a password defined in `config.php`
- add login/logout pages with cookie support
- add `auth.php` helper for access control
- link to logout in main pages
- update README with instructions

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a3eecd30832aa405489ec709c63c